### PR TITLE
MikeO Initial Pass

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,19 @@
 # License
 
+Copyright (c) 2025 IETF Trust and the persons identified as the
+document authors.  All rights reserved.
+
+This document is subject to BCP 78 and the IETF Trust's Legal
+Provisions Relating to IETF Documents
+(https://trustee.ietf.org/license-info) in effect on the date of
+publication of this document.  Please review these documents
+carefully, as they describe your rights and restrictions with respect
+to this document.  Code Components extracted from this document must
+include Simplified BSD License text as described in Section 4.e of
+the Trust Legal Provisions and are provided without warranty as
+described in the Simplified BSD License.
+
+
+
 See the
 [guidelines for contributions](https://github.com/hannestschofenig/tls-dual-certs/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
I started writing out a more formal set of design goals, but then I got to Section 5 and realized that this document is not accomplishing what I believe is a core design requirement, which is the ability to express the following:

> "I would accept any SLH-DSA by itself, and ML-DSA-44 and ML-DSA-65 only in a dual-cert hybrid with RSA, ECDSA P-256 or ECDSA P-384."
> or
> "I would accept MLDSA65_RSA2048 or MLDSA65_ECDSA-P256 by themselves or ML-DSA-65 in a dual-cert hybrid with RSA or ECDSA P-256."


I also made other editorial impromevents, and I added a few in-line questions / comments.